### PR TITLE
Have apache listen for cvn.wmcloud.org as well

### DIFF
--- a/apache-config/cvn.conf
+++ b/apache-config/cvn.conf
@@ -5,7 +5,9 @@
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
 
 <VirtualHost *:80>
-	ServerName cvn.wmflabs.org
+	ServerName cvn.wmcloud.org
+	ServerAlias cvn.wmflabs.org
+	UseCanonicalName Off
 
 	DocumentRoot /srv/cvn/services/www
 


### PR DESCRIPTION
*.wmflabs.org is no longer in fashion[1], so it probably makes sense to migrate as we migrate webserver instances as well. This patch makes Apache respond to both equally and not redirect from one to the other.

[1]: https://wikitech.wikimedia.org/wiki/Help:Using_a_web_proxy_to_reach_Cloud_VPS_servers_from_the_internet#Migrate_from_a_*.wmflabs.org_proxy_to_a_*.wmcloud.org_proxy